### PR TITLE
New feature "Send from course: " in the message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - MOODLE_310_STABLE
+      - MOODLE_39_STABLE
 
 env:
   php: 7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: Integration & Unit test
+
+on:
+  pull_request:
+    branches:
+      - master
+      - MOODLE_310_STABLE
+
+env:
+  php: 7.4
+
+jobs:
+  PHPUnit:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            php: 7.4
+            db: mysqli
+            moodle: MOODLE_310_STABLE
+            plugin_branch: MOODLE_310_STABLE
+
+    steps:
+      - name: Setting up DB mysql
+        if: ${{ matrix.db == 'mysqli' }}
+        uses: johanmeiring/mysql-action@tmpfs-patch
+        with:
+          collation server: utf8mb4_danish_ci
+          mysql version: 8.0
+          mysql database: test
+          mysql user: test
+          mysql password: test
+          use tmpfs: true
+
+      - name: Setting up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Checking out code from moodle/moodle
+        uses: actions/checkout@v2
+        with:
+          repository: moodle/moodle
+          ref: ${{ matrix.moodle }}
+
+      - name: Check out code from ${{ github.repository }}
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/local/augmented_teacher
+          ref: ${{ github.ref }}
+
+      - name: Lint module code
+        run:
+          find $GITHUB_WORKSPACE/local/augmented_teacher -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
+
+      - name: Setting up PHPUnit
+        env:
+          dbtype: ${{ matrix.db }}
+        run: |
+          echo "pathtophp=$(which php)" >> $GITHUB_ENV # Inject installed pathtophp to env. The template config needs it.
+          cp $GITHUB_WORKSPACE/.github/workflows/config-template.php $GITHUB_WORKSPACE/config.php
+          mkdir $GITHUB_WORKSPACE/../moodledata
+          sudo locale-gen en_AU.UTF-8
+          php $GITHUB_WORKSPACE/admin/tool/phpunit/cli/init.php --no-composer-self-update
+      - name: Running PHPUnit tests
+        env:
+          dbtype: ${{ matrix.db }}
+        run: $GITHUB_WORKSPACE/vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml --testsuite=local_augmented_teacher_testsuite -v --testdox

--- a/classes/factory.php
+++ b/classes/factory.php
@@ -26,4 +26,33 @@ class factory
     public static function get_message_send_from_course_builder($lang_string = null) {
         return new message_send_from_course_builder($lang_string);
     }
+
+    /**
+     * @param string $message
+     * @param object $course
+     * @param null|object $user
+     * @return string
+     */
+    public static function append_message_send_from_course($message, $course, $user = null) {
+        try {
+            $can_append_message = (bool)get_config(
+                'local_augmented_teacher',
+                'show_send_from_course_in_message'
+            );
+
+            if (!$can_append_message) {
+                return $message;
+            }
+
+            return self::get_message_send_from_course_builder()->append(
+                $message,
+                $course,
+                $user
+            );
+        }
+        catch (\Exception $exception) {
+        }
+
+        return $message;
+    }
 }

--- a/classes/factory.php
+++ b/classes/factory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package     local_augmented_teacher
+ * @author      Praxis A/S
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright   (C) 2017 SmartLearning Inc https://www.smartlearning.dk
+ */
+
+namespace local_augmented_teacher;
+
+use lang_string;
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/**
+ * Class factory
+ * @package local_augmented_teacher
+ */
+class factory
+{
+    /**
+     * @param lang_string|null $lang_string
+     * @return message_send_from_course_builder
+     */
+    public static function get_message_send_from_course_builder($lang_string = null) {
+        return new message_send_from_course_builder($lang_string);
+    }
+}

--- a/classes/message_send_from_course_builder.php
+++ b/classes/message_send_from_course_builder.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @package     local_augmented_teacher
+ * @author      Praxis A/S
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright   (C) 2017 SmartLearning Inc https://www.smartlearning.dk
+ */
+
+namespace local_augmented_teacher;
+
+use coding_exception;
+use dml_exception;
+use Exception;
+use InvalidArgumentException;
+use lang_string;
+use moodle_database;
+use moodle_exception;
+use moodle_url;
+use UnexpectedValueException;
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/**
+ * Class message_send_from_course_builder
+ * @package local_augmented_teacher
+ */
+class message_send_from_course_builder
+{
+    private $lang_string;
+
+    /**
+     * message_send_from_course_builder constructor.
+     * @param lang_string|null $lang_string
+     */
+    public function __construct($lang_string = null) {
+        $this->lang_string = $lang_string;
+    }
+
+    /**
+     * @param string $message
+     * @param object $course
+     * @param object|null $user
+     * @return string
+     * @throws coding_exception
+     * @throws moodle_exception
+     */
+    public function append($message, $course, $user = null) {
+
+        if ($user !== null) {
+            try {
+                return $message . $this->get_send_from_course_text($course, $this->get_user_language($user));
+            }
+            catch (Exception $exception) {
+                // Skip and use moodle default language
+            }
+        }
+
+        return $message . $this->get_send_from_course_text($course);
+    }
+
+    /**
+     * @param object $course
+     * @param string|null $lang
+     * @return string
+     * @throws coding_exception
+     * @throws moodle_exception
+     */
+    private function get_send_from_course_text($course, $lang = null) {
+        if ($this->lang_string === null) {
+            $this->lang_string = new lang_string(
+                'sendfromcourse',
+                'local_augmented_teacher',
+                $this->get_course_instance($course)
+            );
+        }
+        return $this->lang_string->out($lang);
+    }
+
+    /**
+     * @param object $user
+     * @return string
+     * @throws dml_exception
+     */
+    private function get_user_language($user) {
+
+        if (!empty($user->lang)) {
+            return $user->lang;
+        }
+
+        if (!isset($user->id)) {
+            throw new InvalidArgumentException('User instance is missing the id property');
+        }
+
+        $lang = $this->db()->get_field(
+            'user',
+            'lang',
+            ['id' => $user->id]
+        );
+
+        if (!$lang) {
+            throw new UnexpectedValueException("User had not yet set the language in the profile");
+        }
+
+        return $lang;
+    }
+
+    /**
+     * @param object $course
+     * @return object
+     * @throws moodle_exception
+     */
+    private function get_course_instance($course) {
+
+        $course_id = $course->id ?? 0;
+        $url = $this->get_course_url($course_id);
+
+        return (object)[
+            'link' => '<a href="'. $url .'">'. $course->fullname .'</a>',
+            'url' => $url,
+            'id' => (int)$course_id,
+            'fullname' => $course->fullname ?? '',
+            'shortname' => $course->shortname ?? '',
+        ];
+    }
+
+    /**
+     * @param int $course_id
+     * @return string
+     * @throws moodle_exception
+     */
+    private function get_course_url($course_id) {
+        $url = new moodle_url('/course/view.php', ['id' => $course_id]);
+        return $url->out(false);
+    }
+
+    /**
+     * @return moodle_database
+     */
+    private function db() {
+        global $DB;
+        return $DB;
+    }
+}

--- a/lang/en/local_augmented_teacher.php
+++ b/lang/en/local_augmented_teacher.php
@@ -134,6 +134,8 @@ $string['previewhtml'] = 'HTML format preview';
  * }
  */
 $string['sendfromcourse'] = '<p style="text-align: right;">Send from: {$a->link}</p>';
+$string['show_send_from_course_in_message'] = 'Show send from course link in the message';
+$string['show_send_from_course_in_message_desc'] = 'The text can be modified in language string with "sendfromcourse" identifier.';
 
 // Capabilities
 $string['augmented_teacher:receivereminder'] = 'Receive reminder';

--- a/lang/en/local_augmented_teacher.php
+++ b/lang/en/local_augmented_teacher.php
@@ -124,6 +124,16 @@ $string['formattexttype'] = 'Formatting';
 $string['currentlyselectedusers'] = 'Currently selected users';
 $string['allfieldsrequired'] = 'All fields are required';
 $string['previewhtml'] = 'HTML format preview';
+/**
+ * $a: {
+ *      id: int,
+ *      fullname: string,
+ *      shortname: string,
+ *      url: string,
+ *      link: string (HTMLElement <a>...</a>)
+ * }
+ */
+$string['sendfromcourse'] = '<p style="text-align: right;">Send from: {$a->link}</p>';
 
 // Capabilities
 $string['augmented_teacher:receivereminder'] = 'Receive reminder';

--- a/lib.php
+++ b/lib.php
@@ -23,6 +23,9 @@
  * @copyright  (C) 2017 SmartLearning Inc https://www.smartlearning.dk
  */
 
+use local_augmented_teacher\factory;
+use local_augmented_teacher\message_send_from_course_builder;
+
 defined('MOODLE_INTERNAL') || die();
 
 define('REMINDER_BEFORE_DUE', 1);
@@ -212,6 +215,13 @@ function local_augmented_teacher_send_reminder_message() {
                     $message = str_replace($search, $replace, $reminder->message);
                     $message = text_to_html($message);
                     $message = html_entity_decode($message);
+
+                    $message = factory::get_message_send_from_course_builder()->append(
+                        $message,
+                        $course,
+                        $user
+                    );
+
                     if ($mid = message_post_message($userfrom, $user, $message, FORMAT_HTML)) {
                         $log = new stdClass();
                         $log->userid = $user->id;
@@ -311,7 +321,6 @@ function local_augmented_teacher_send_notloggedin_reminder_message() {
                 }
 
                 $users = get_enrolled_users($context, 'local/augmented_teacher:receivereminder');
-                //enrol_get_course_users('d')
 
 
                 foreach ($users as $user) {
@@ -339,6 +348,14 @@ function local_augmented_teacher_send_notloggedin_reminder_message() {
                     $message = str_replace($search, $replace, $reminder->message);
                     $message = text_to_html($message);
                     $message = html_entity_decode($message);
+
+                    // Inject send from course URL
+                    $message = factory::get_message_send_from_course_builder()->append(
+                        $message,
+                        $course,
+                        $user
+                    );
+
                     if ($mid = message_post_message($userfrom, $user, $message, FORMAT_HTML)) {
                         $log = new stdClass();
                         $log->userid = $user->id;
@@ -514,6 +531,12 @@ function local_augmented_teacher_send_activity_recommendation() {
                      $message = str_replace($search, $replace, $reminder->message);
                      $message = text_to_html($message);
                      $message = html_entity_decode($message);
+                     $message = factory::get_message_send_from_course_builder()->append(
+                         $message,
+                         $course,
+                         $user
+                     );
+
                      if ($mid = message_post_message($userfrom, $user, $message, FORMAT_HTML)) {
                          $log = new stdClass();
                          $log->userid = $user->id;

--- a/lib.php
+++ b/lib.php
@@ -216,7 +216,7 @@ function local_augmented_teacher_send_reminder_message() {
                     $message = text_to_html($message);
                     $message = html_entity_decode($message);
 
-                    $message = factory::get_message_send_from_course_builder()->append(
+                    $message = factory::append_message_send_from_course(
                         $message,
                         $course,
                         $user
@@ -349,7 +349,7 @@ function local_augmented_teacher_send_notloggedin_reminder_message() {
                     $message = text_to_html($message);
                     $message = html_entity_decode($message);
 
-                    $message = factory::get_message_send_from_course_builder()->append(
+                    $message = factory::append_message_send_from_course(
                         $message,
                         $course,
                         $user
@@ -530,7 +530,7 @@ function local_augmented_teacher_send_activity_recommendation() {
                      $message = str_replace($search, $replace, $reminder->message);
                      $message = text_to_html($message);
                      $message = html_entity_decode($message);
-                     $message = factory::get_message_send_from_course_builder()->append(
+                     $message = factory::append_message_send_from_course(
                          $message,
                          $course,
                          $user

--- a/messageselect.php
+++ b/messageselect.php
@@ -23,6 +23,9 @@
  * @copyright  (C) 2017 SmartLearning Inc https://www.smartlearning.dk
  */
 
+use local_augmented_teacher\factory;
+use local_augmented_teacher\message_send_from_course_builder;
+
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
 require_once($CFG->dirroot.'/message/lib.php');
 
@@ -187,10 +190,16 @@ if (!empty($messagebody) && !$edit && !$deluser && ($preview || $send)) {
 
                 $messagebodywithshortcode = str_replace($search, $replace, $messagebody);
 
+                $messagebodywithshortcode = factory::get_message_send_from_course_builder()->append(
+                    $messagebodywithshortcode,
+                    $course,
+                    $user
+                );
+
                 if (!message_post_message($USER, $user, $messagebodywithshortcode, $format)) {
                     $user->fullname = fullname($user);
                     $fails[] = get_string('messagedselecteduserfailed', 'moodle', $user);
-                };
+                }
             }
             if (empty($fails)) {
                 echo $OUTPUT->heading(get_string('messagedselectedusers'));

--- a/messageselect.php
+++ b/messageselect.php
@@ -190,7 +190,7 @@ if (!empty($messagebody) && !$edit && !$deluser && ($preview || $send)) {
 
                 $messagebodywithshortcode = str_replace($search, $replace, $messagebody);
 
-                $messagebodywithshortcode = factory::get_message_send_from_course_builder()->append(
+                $messagebodywithshortcode = factory::append_message_send_from_course(
                     $messagebodywithshortcode,
                     $course,
                     $user

--- a/settings.php
+++ b/settings.php
@@ -38,4 +38,16 @@ $settings->add(new admin_setting_configselect('local_augmented_teacher/recommend
     get_string('recommendactivityhour', 'local_augmented_teacher'), '', 6, $options)
 );
 
+$yesno = [
+    0 => get_string('no'),
+    1 => get_string('yes'),
+];
+$settings->add(new admin_setting_configselect(
+    'local_augmented_teacher/show_send_from_course_in_message',
+    get_string('show_send_from_course_in_message', 'local_augmented_teacher'),
+    get_string('show_send_from_course_in_message_desc', 'local_augmented_teacher'),
+    0,
+    $yesno
+));
+
 $ADMIN->add('localplugins', $settings);

--- a/tests/unit/message_send_from_course_builder_test.php
+++ b/tests/unit/message_send_from_course_builder_test.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @package     local_augmented_teacher\integration
+ * @copyright   2021 Praxis
+ * @companyinfo https://praxis.dk
+ */
+
+namespace local_augmented_teacher\unit;
+
+use basic_testcase;
+use coding_exception;
+use lang_string;
+use local_augmented_teacher\message_send_from_course_builder;
+use moodle_exception;
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/**
+ * Class message_send_from_course_builder_test
+ * @package local_augmented_teacher\integration
+ */
+class message_send_from_course_builder_test extends basic_testcase
+{
+    /**
+     * @dataProvider language_provider
+     * @param string $lang
+     * @throws coding_exception
+     * @throws moodle_exception
+     */
+    public function test_append_send_from_course_text_to_message(string $lang): void {
+
+        $strings = [
+            'en' => 'A English test text',
+            'da' => 'A Danish test text',
+        ];
+
+        $message = 'This is a test message.';
+        // Expect non-exists language to use English as default
+        $lang_text = $strings[$lang] ?? $strings['en'];
+        $expected_message = $message . $lang_text;
+
+        $course = (object)[
+            'id' => 1,
+            'fullname' => 'This is a test course 1'
+        ];
+
+        $student = (object)[
+            'id' => 1,
+            'lang' => $lang
+        ];
+
+        $lang_string = $this->mock_lang_string($strings);
+
+        $builder = new message_send_from_course_builder($lang_string);
+        $actual_message = $builder->append(
+            $message,
+            $course,
+            $student
+        );
+
+        self::assertSame($expected_message, $actual_message);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function language_provider(): array {
+        return [
+            ['da'],
+            ['en'],
+            ['es'],
+        ];
+    }
+
+    /**
+     * @param string[] $langs ["en" => "Some english text"]
+     * @return lang_string
+     */
+    private function mock_lang_string(array $langs): lang_string {
+
+        $default_lang = 'en';
+        $string = $this->createMock(lang_string::class);
+        $string->expects(self::once())
+            ->method('out')
+            ->willReturnCallback(function($lang) use($langs, $default_lang) {
+                if (!isset($langs[$lang])) {
+                    // Simulate moodle lang_string::out() error
+                    if (!isset($langs[$default_lang])) {
+                        throw new coding_exception("Cannot find the language $lang or $default_lang");
+                    }
+                    $lang = $default_lang;
+                }
+                return $langs[$lang];
+            });
+        return $string;
+    }
+}

--- a/tests/unit/message_send_from_course_builder_test.php
+++ b/tests/unit/message_send_from_course_builder_test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     local_augmented_teacher\integration
+ * @package     local_augmented_teacher\unit
  * @copyright   2021 Praxis
  * @companyinfo https://praxis.dk
  */
@@ -18,7 +18,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class message_send_from_course_builder_test
- * @package local_augmented_teacher\integration
+ * @package local_augmented_teacher\unit
  */
 class message_send_from_course_builder_test extends basic_testcase
 {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2020093000;
+$plugin->version  = 2021061500;
 $plugin->requires = 2018051700; // Moodle 3.5 required.
 $plugin->component = 'local_augmented_teacher';
-$plugin->release = '1.4.3';
+$plugin->release = '1.4.4';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021061500;
+$plugin->version  = 2021061501;
 $plugin->requires = 2018051700; // Moodle 3.5 required.
 $plugin->component = 'local_augmented_teacher';
 $plugin->release = '1.4.4';


### PR DESCRIPTION
Add new feature that add a text "Send from [course name with link]: " at the bottom of the message/email.
The text can be change and customize by modify language string with id "sendfromcourse" in the Language customization.