### PR TITLE
Fixed Moodle 4.2+ deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,10 @@ name: Integration & Unit test
 on:
   pull_request:
     branches:
-      - master
-      - MOODLE_310_STABLE
-      - MOODLE_39_STABLE
+      - MOODLE_42_STABLE
 
 env:
-  php: 7.4
+  php: 8.0
 
 jobs:
   PHPUnit:
@@ -17,10 +15,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            php: 7.4
+            php: 8.0
             db: mysqli
-            moodle: MOODLE_310_STABLE
-            plugin_branch: MOODLE_310_STABLE
+            moodle: MOODLE_42_STABLE
+            plugin_branch: MOODLE_42_STABLE
+          - os: ubuntu-20.04
+            php: 8.1
+            db: mysqli
+            moodle: MOODLE_42_STABLE
+            plugin_branch: MOODLE_42_STABLE
+          - os: ubuntu-20.04
+            php: 8.2
+            db: mysqli
+            moodle: MOODLE_42_STABLE
+            plugin_branch: MOODLE_42_STABLE
 
     steps:
       - name: Setting up DB mysql
@@ -41,13 +49,13 @@ jobs:
           coverage: none
 
       - name: Checking out code from moodle/moodle
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: moodle/moodle
           ref: ${{ matrix.moodle }}
 
       - name: Check out code from ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/local/augmented_teacher
           ref: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,17 @@ jobs:
           - os: ubuntu-20.04
             php: 8.0
             db: mysqli
-            moodle: MOODLE_42_STABLE
+            moodle: MOODLE_402_STABLE
             plugin_branch: MOODLE_42_STABLE
           - os: ubuntu-20.04
             php: 8.1
             db: mysqli
-            moodle: MOODLE_42_STABLE
+            moodle: MOODLE_402_STABLE
             plugin_branch: MOODLE_42_STABLE
           - os: ubuntu-20.04
             php: 8.2
             db: mysqli
-            moodle: MOODLE_42_STABLE
+            moodle: MOODLE_402_STABLE
             plugin_branch: MOODLE_42_STABLE
 
     steps:
@@ -47,6 +47,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
+          ini-values: 'max_input_vars=5000'
 
       - name: Checking out code from moodle/moodle
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Allow users to:
 Requirements
 ------------
 
-Moodle 3.2 or greater.
+Moodle 4.2 or greater.
 
 Installation
 ------------

--- a/action_redir.php
+++ b/action_redir.php
@@ -43,11 +43,11 @@ $actions = array(
 );
 
 if (array_search($formaction, $actions) === false) {
-    print_error('unknownuseraction');
+    throw new \moodle_exception('unknownuseraction', 'error');
 }
 
 if (!confirm_sesskey()) {
-    print_error('confirmsesskeybad');
+    throw new \moodle_exception('confirmsesskeybad', 'error');
 }
 
 require_once($formaction);

--- a/lib.php
+++ b/lib.php
@@ -122,7 +122,7 @@ function local_augmented_teacher_send_reminder_message() {
         return;
     }
 
-    cron_setup_user(null, null, true);
+    \core\cron::setup_user(null, null, true);
 
     $reminders_repo = \local_augmented_teacher\reminders_factory::get_repository();
     $reminders = $reminders_repo->get_activity_reminders();
@@ -250,7 +250,7 @@ function local_augmented_teacher_send_notloggedin_reminder_message() {
 
     mtrace('Processing not logged in reminders...');
 
-    cron_setup_user(null, null, true);
+    \core\cron::setup_user(null, null, true);
 
     $reminders_repo = \local_augmented_teacher\reminders_factory::get_repository();
     $reminders = $reminders_repo->get_notloggedin_reminders();
@@ -413,7 +413,7 @@ function local_augmented_teacher_send_activity_recommendation() {
 
     mtrace('Processing recommended activity messages...');
 
-    cron_setup_user(null, null, true);
+    \core\cron::setup_user(null, null, true);
 
     $reminders_repo = \local_augmented_teacher\reminders_factory::get_repository();
     $reminders = $reminders_repo->get_activity_reminders();
@@ -620,9 +620,9 @@ function local_augmented_teacher_pix_url($imagename, $component=null) {
     global $CFG, $OUTPUT;
     if ($CFG->branch >= 33) { // MDL 3.3+.
         return $OUTPUT->image_url($imagename, $component);
-    } else {
-        return $OUTPUT->pix_url($imagename, $component);
     }
+
+    return $OUTPUT->pix_icon($imagename, '', $component);
 }
 
 function local_augmented_get_first_firstname($firstname) {

--- a/messageselect.php
+++ b/messageselect.php
@@ -99,7 +99,7 @@ $count = 0;
 
 if ($data = data_submitted()) {
     require_sesskey();
-    $namefields = get_all_user_name_fields(true);
+    $namefields = implode(',', \core_user\fields::get_name_fields());
     foreach ($data as $k => $v) {
         if (preg_match('/^(user|teacher)(\d+)$/', $k, $m)) {
             if (!array_key_exists($m[2], $SESSION->emailto[$id])) {

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var stdClass $plugin */
 $plugin->component = 'local_augmented_teacher';
-$plugin->version  = 2022073000;
-$plugin->requires = 2018051700; // Moodle 3.5 required.
-$plugin->release = '1.5.0';
+$plugin->version  = 2024101700;
+$plugin->requires = 2023042400; // Moodle 4.2 required.
+$plugin->release = '1.6.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Moodle have changed the placement of individual methods, to core / core_user / etc., and therefore an update was needed for it to work in 4.2 and up.